### PR TITLE
Fix base64 utilities in JS runtime

### DIFF
--- a/pkg/nodes/code/javascript_runtime.go
+++ b/pkg/nodes/code/javascript_runtime.go
@@ -3,6 +3,7 @@ package code
 import (
 	"context"
 	"crypto/md5"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -176,13 +177,15 @@ func (js *JavaScriptRuntime) createUtilities(vm *goja.Runtime) *goja.Object {
 
 	// Base64 utilities
 	utils.Set("base64Encode", func(str string) string {
-		// TODO: Implement base64 encoding
-		return str
+		return base64.StdEncoding.EncodeToString([]byte(str))
 	})
 
 	utils.Set("base64Decode", func(str string) string {
-		// TODO: Implement base64 decoding
-		return str
+		decoded, err := base64.StdEncoding.DecodeString(str)
+		if err != nil {
+			return ""
+		}
+		return string(decoded)
 	})
 
 	return utils

--- a/pkg/nodes/code/javascript_runtime_test.go
+++ b/pkg/nodes/code/javascript_runtime_test.go
@@ -218,6 +218,36 @@ func TestJavaScriptRuntime_Execute_UtilityFunctions(t *testing.T) {
 	assert.Equal(t, `{"test":true}`, resultMap["stringified"])
 }
 
+func TestJavaScriptRuntime_Execute_Base64Utilities(t *testing.T) {
+	runtime := NewJavaScriptRuntime()
+	require.NoError(t, runtime.Initialize())
+
+	execContext := CodeExecutionContext{
+		Data:      map[string]interface{}{},
+		Variables: map[string]interface{}{},
+		NodeData:  map[string]interface{}{},
+		NodeID:    "node-123",
+		AgentID:   "agent-456",
+	}
+
+	code := `
+        const encoded = utils.base64Encode("hello world");
+        const decoded = utils.base64Decode(encoded);
+        const invalid = utils.base64Decode("!invalid!");
+        return { encoded: encoded, decoded: decoded, invalid: invalid };
+    `
+
+	result, err := runtime.Execute(context.Background(), code, execContext)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "aGVsbG8gd29ybGQ=", resultMap["encoded"])
+	assert.Equal(t, "hello world", resultMap["decoded"])
+	assert.Equal(t, "", resultMap["invalid"])
+}
+
 func TestJavaScriptRuntime_Execute_Console(t *testing.T) {
 	runtime := NewJavaScriptRuntime()
 	require.NoError(t, runtime.Initialize())


### PR DESCRIPTION
## Summary
- implement base64 encoding/decoding helpers in `JavaScriptRuntime`
- cover new base64 helpers with tests

## Testing
- `go vet ./...` *(fails: go1.24.4 download blocked)*
- `go fmt ./...` *(fails: go1.24.4 download blocked)*
- `go test ./...` *(fails: go1.24.4 download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855d50d3464832b8ffdf871b02f45f5